### PR TITLE
[build] Corrected src/Makefile.am for MinGW/Msys

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,9 @@ libp11_la_LDFLAGS = $(AM_LDFLAGS) \
 
 if HAVE_LD_VERSION_SCRIPT
 libp11_la_LDFLAGS += -Wl,--version-script="$(srcdir)/libp11.map"
+if WIN32
+libp11_la_LDFLAGS += -export-symbols "$(srcdir)/libp11.exports"
+endif
 else
 libp11_la_LDFLAGS += -export-symbols "$(srcdir)/libp11.exports"
 endif


### PR DESCRIPTION
Corrects this error by configuring linker to export missing def file on WIN32 platform:
/usr/bin/install: cannot stat „./.libs/libp11-2.dll.def”: No such file or directory